### PR TITLE
Add initial LifeOS chessboard prototype

### DIFF
--- a/LifeOSApp/CasaVidaOSApp.swift
+++ b/LifeOSApp/CasaVidaOSApp.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+@main
+struct CasaVidaOSApp: App {
+    @State private var archetype: Archetype = .franklin
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack {
+                VStack {
+                    ArchetypeSelectorView(selected: $archetype)
+                    ChessboardView()
+                }
+                .navigationTitle("Casa-VidaOS")
+            }
+        }
+    }
+}

--- a/LifeOSApp/Models/LifeModels.swift
+++ b/LifeOSApp/Models/LifeModels.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftUI
+
+enum LifePieceType: String, CaseIterable, Identifiable {
+    case king, queen, rook, bishop, knight, pawn
+    var id: String { rawValue }
+}
+
+struct LifePiece: Identifiable {
+    let id: UUID
+    let type: LifePieceType
+    let domain: String
+    var position: (Int, Int)
+    var progressLevel: Int
+}
+
+enum Archetype: String, CaseIterable, Identifiable {
+    case franklin, daVinci, tesla, aurelius, musashi
+    var id: String { rawValue }
+
+    var description: String {
+        switch self {
+        case .franklin:
+            return "Order and discipline with the 13 virtues."
+        case .daVinci:
+            return "Endless curiosity and creativity."
+        case .tesla:
+            return "Deep focus and visionary projects."
+        case .aurelius:
+            return "Stoic reflection and purposeful duty."
+        case .musashi:
+            return "Minimalism and relentless training."
+        }
+    }
+}

--- a/LifeOSApp/ViewModels/ChessboardViewModel.swift
+++ b/LifeOSApp/ViewModels/ChessboardViewModel.swift
@@ -1,0 +1,35 @@
+import Foundation
+import SwiftUI
+
+class ChessboardViewModel: ObservableObject {
+    @Published var tiles: [[LifeBoardTile]] = []
+    @Published var pieces: [LifePiece] = []
+
+    init() {
+        setupBoard()
+    }
+
+    func setupBoard() {
+        tiles = (0..<8).map { row in
+            (0..<8).map { col in
+                LifeBoardTile(row: row, col: col, piece: nil)
+            }
+        }
+
+        pieces = [
+            LifePiece(id: UUID(), type: .king, domain: "Virtue", position: (0,4), progressLevel: 5),
+            LifePiece(id: UUID(), type: .queen, domain: "Time", position: (0,3), progressLevel: 7)
+        ]
+
+        for piece in pieces {
+            tiles[piece.position.0][piece.position.1].piece = piece
+        }
+    }
+}
+
+struct LifeBoardTile: Identifiable {
+    let id = UUID()
+    let row: Int
+    let col: Int
+    var piece: LifePiece?
+}

--- a/LifeOSApp/Views/ArchetypeSelectorView.swift
+++ b/LifeOSApp/Views/ArchetypeSelectorView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct ArchetypeSelectorView: View {
+    @Binding var selected: Archetype
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 16) {
+                ForEach(Archetype.allCases) { archetype in
+                    VStack {
+                        Text(archetype.rawValue.capitalized)
+                            .font(.headline)
+                        Text(archetype.description)
+                            .font(.caption)
+                            .multilineTextAlignment(.center)
+                        Button("Select") {
+                            selected = archetype
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .padding()
+                    .background(RoundedRectangle(cornerRadius: 8).stroke(Color.blue))
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    StateWrapper()
+}
+
+private struct StateWrapper: View {
+    @State var selected: Archetype = .franklin
+    var body: some View {
+        ArchetypeSelectorView(selected: $selected)
+    }
+}

--- a/LifeOSApp/Views/ChessboardView.swift
+++ b/LifeOSApp/Views/ChessboardView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct ChessboardView: View {
+    @StateObject private var viewModel = ChessboardViewModel()
+
+    var body: some View {
+        VStack {
+            Text("Life OS Chessboard")
+                .font(.largeTitle)
+                .padding()
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 8), spacing: 2) {
+                ForEach(viewModel.tiles.flatMap { $0 }) { tile in
+                    ZStack {
+                        Rectangle()
+                            .fill((tile.row + tile.col) % 2 == 0 ? Color.gray.opacity(0.3) : Color.gray.opacity(0.6))
+                            .frame(height: 44)
+                        if let piece = tile.piece {
+                            Text(String(piece.type.rawValue.prefix(1)).uppercased())
+                                .foregroundColor(.white)
+                                .frame(width: 32, height: 32)
+                                .background(Color.blue)
+                                .clipShape(Circle())
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ChessboardView()
+}

--- a/LifeOSApp/Views/PersonaQuizView.swift
+++ b/LifeOSApp/Views/PersonaQuizView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct QuizQuestion {
+    let text: String
+    let options: [Archetype]
+}
+
+struct PersonaQuizView: View {
+    @State private var index = 0
+    @State private var scores: [Archetype:Int] = [:]
+
+    private let questions: [QuizQuestion] = [
+        QuizQuestion(text: "How do you start your day?", options: [.franklin, .aurelius, .musashi]),
+        QuizQuestion(text: "Preferred focus?", options: [.daVinci, .tesla, .franklin])
+    ]
+
+    var body: some View {
+        VStack(spacing: 20) {
+            if index < questions.count {
+                Text(questions[index].text)
+                    .font(.headline)
+                ForEach(questions[index].options, id: \..self) { archetype in
+                    Button(archetype.rawValue.capitalized) {
+                        scores[archetype, default: 0] += 1
+                        index += 1
+                    }
+                    .buttonStyle(.bordered)
+                }
+            } else {
+                if let best = scores.max(by: { $0.value < $1.value })?.key {
+                    Text("You match \(best.rawValue.capitalized)")
+                        .font(.title2)
+                } else {
+                    Text("Quiz complete")
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    PersonaQuizView()
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
 # Casa-VidaOS
+
+Casa-VidaOS is an experimental Life Operating System for iOS built using Swift and SwiftUI. It visualizes your routines and goals as pieces on a chessboard. Inspired by historical figures like Benjamin Franklin and Leonardo da Vinci, the app encourages daily reflection, habit tracking, and virtue cultivation.
+
+## Features
+- Interactive chessboard dashboard representing life domains
+- Virtue tracker with weekly focus
+- Challenge engine to maintain habit streaks
+- Chaos Engine introducing random events
+- Archetype selector representing different play styles
+- Journal for morning and evening reflection
+
+## Project Structure
+```
+Casa-VidaOS/
+├── README.md
+├── docs/
+│   ├── DESIGN.md
+│   └── wireframes/
+└── LifeOSApp/
+    ├── Models/
+    ├── Views/
+    ├── ViewModels/
+    └── CasaVidaOSApp.swift
+```
+
+## Getting Started
+1. Open `LifeOSApp` as an Xcode project or integrate these files into a new SwiftUI project.
+2. Build and run the app on iOS 17 or later.
+
+## Building
+This repository only includes Swift source files. Create an Xcode project named **LifeOSApp** and add the contents of `LifeOSApp/`. Ensure SwiftData/CoreData capability is enabled for persistence.
+
+## License
+MIT

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,43 @@
+# Casa-VidaOS Design
+
+Casa-VidaOS is built using the Model-View-ViewModel (MVVM) pattern. Each major feature is encapsulated in its own engine module to allow future expansion.
+
+## Modules
+- **ChessboardEngine** – Renders an 8x8 board and moves pieces based on habits and challenges.
+- **JournalEngine** – Handles morning/evening reflections stored via Core Data.
+- **ChallengeEngine** – Manages habit streaks and random chaos events.
+- **ArchetypeEngine** – Allows users to switch between historical archetypes such as Benjamin Franklin or Musashi. Each archetype can influence the UI theme and default challenges.
+
+## Data Models
+```swift
+enum LifePieceType: String, CaseIterable, Identifiable {
+    case king, queen, rook, bishop, knight, pawn
+    var id: String { rawValue }
+}
+
+struct LifePiece: Identifiable {
+    let id: UUID
+    let type: LifePieceType
+    let domain: String
+    var position: (Int, Int)
+    var progressLevel: Int
+}
+
+enum Archetype: String, CaseIterable {
+    case franklin, daVinci, tesla, aurelius, musashi
+}
+```
+
+## Views
+- **ChessboardView** – Displays the grid of tiles with piece icons.
+- **ArchetypeSelectorView** – Cards for each archetype with descriptions.
+- **JournalView** – Morning and evening prompts.
+- **PersonaQuizView** – Suggests an archetype after a short questionnaire.
+
+## Wireframes
+Wireframe images should be placed in `docs/wireframes/`. They illustrate the chessboard layout and the archetype selector carousel.
+
+## Future Work
+- Add data persistence with SwiftData.
+- Implement a Chaos Engine that schedules random events.
+- Create shareable reports summarizing weekly progress.

--- a/docs/wireframes/README.md
+++ b/docs/wireframes/README.md
@@ -1,0 +1,1 @@
+Wireframes for chessboard and archetype selector.


### PR DESCRIPTION
## Summary
- flesh out `README.md` with project overview and build instructions
- document architecture in `docs/DESIGN.md`
- add placeholder wireframes directory
- create SwiftUI skeleton with models, view models and views for a chessboard-based Life OS

## Testing
- `swift --version`
- `swiftc LifeOSApp/Models/LifeModels.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6840a6576e808332b891ce7acde34f70