### PR TITLE
Add persistence and chaos engine

### DIFF
--- a/LifeOSApp/CasaVidaOSApp.swift
+++ b/LifeOSApp/CasaVidaOSApp.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import SwiftData
+
+@main
+struct CasaVidaOSApp: App {
+    @State private var archetype: Archetype = .franklin
+    @StateObject private var chaosEngine = ChaosEngine()
+
+    var body: some Scene {
+        WindowGroup {
+            NavigationStack {
+                VStack {
+                    ArchetypeSelectorView(selected: $archetype)
+                    ChessboardView(archetype: $archetype)
+                    NavigationLink("Weekly Report") {
+                        WeeklyReportView()
+                    }
+                }
+                .navigationTitle("Casa-VidaOS")
+                .onAppear {
+                    chaosEngine.start()
+                }
+                .onDisappear {
+                    chaosEngine.stop()
+                }
+            }
+            .modelContainer(DataController.shared.container)
+        }
+    }
+}

--- a/LifeOSApp/Models/LifeModels.swift
+++ b/LifeOSApp/Models/LifeModels.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+enum LifePieceType: String, CaseIterable, Identifiable {
+    case king, queen, rook, bishop, knight, pawn
+    var id: String { rawValue }
+}
+
+struct LifePiece: Identifiable {
+    let id: UUID
+    let type: LifePieceType
+    let domain: String
+    var position: (Int, Int)
+    var progressLevel: Int
+}
+
+enum Archetype: String, CaseIterable, Identifiable {
+    case franklin, daVinci, tesla, aurelius, musashi
+    var id: String { rawValue }
+
+    var description: String {
+        switch self {
+        case .franklin:
+            return "Order and discipline with the 13 virtues."
+        case .daVinci:
+            return "Endless curiosity and creativity."
+        case .tesla:
+            return "Deep focus and visionary projects."
+        case .aurelius:
+            return "Stoic reflection and purposeful duty."
+        case .musashi:
+            return "Minimalism and relentless training."
+        }
+    }
+}
+
+struct LifeBoardTile: Identifiable {
+    let id = UUID()
+    let row: Int
+    let col: Int
+    var piece: LifePiece?
+    var statusEffect: String?
+}

--- a/LifeOSApp/Models/PersistenceModels.swift
+++ b/LifeOSApp/Models/PersistenceModels.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftData
+
+@Model
+class LifePieceState {
+    var id: UUID
+    var type: String
+    var domain: String
+    var row: Int
+    var col: Int
+    var progressLevel: Int
+
+    init(id: UUID = UUID(), type: String, domain: String, row: Int, col: Int, progressLevel: Int) {
+        self.id = id
+        self.type = type
+        self.domain = domain
+        self.row = row
+        self.col = col
+        self.progressLevel = progressLevel
+    }
+}
+
+@Model
+class ChaosEvent {
+    var id: UUID
+    var date: Date
+    var text: String
+    var resolved: Bool
+
+    init(id: UUID = UUID(), date: Date = .now, text: String, resolved: Bool = false) {
+        self.id = id
+        self.date = date
+        self.text = text
+        self.resolved = resolved
+    }
+}

--- a/LifeOSApp/Persistence/DataController.swift
+++ b/LifeOSApp/Persistence/DataController.swift
@@ -1,0 +1,17 @@
+import Foundation
+import SwiftData
+
+@MainActor
+class DataController {
+    static let shared = DataController()
+    let container: ModelContainer
+
+    init(inMemory: Bool = false) {
+        let schema = Schema([
+            LifePieceState.self,
+            ChaosEvent.self
+        ])
+        let configuration = ModelConfiguration(isStoredInMemoryOnly: inMemory)
+        container = try! ModelContainer(for: schema, configurations: [configuration])
+    }
+}

--- a/LifeOSApp/ViewModels/ChaosEngine.swift
+++ b/LifeOSApp/ViewModels/ChaosEngine.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftUI
+import SwiftData
+
+@MainActor
+class ChaosEngine: ObservableObject {
+    private let context: ModelContext
+    private var timer: Timer?
+
+    init(context: ModelContext = DataController.shared.container.mainContext) {
+        self.context = context
+    }
+
+    func start() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 86400, repeats: true) { [weak self] _ in
+            self?.createRandomEvent()
+        }
+    }
+
+    func stop() {
+        timer?.invalidate()
+    }
+
+    func createRandomEvent() {
+        let events = [
+            "Unexpected opportunity arises",
+            "Minor setback in your schedule",
+            "New connection wants to collaborate",
+            "You feel low energy today"
+        ]
+        let event = ChaosEvent(text: events.randomElement()!)
+        context.insert(event)
+        try? context.save()
+    }
+}

--- a/LifeOSApp/ViewModels/ChessboardViewModel.swift
+++ b/LifeOSApp/ViewModels/ChessboardViewModel.swift
@@ -1,0 +1,59 @@
+import Foundation
+import SwiftUI
+import SwiftData
+
+class ChessboardViewModel: ObservableObject {
+    @Published var tiles: [[LifeBoardTile]] = []
+    @Published var pieces: [LifePiece] = []
+
+    private let context: ModelContext
+
+    init(context: ModelContext = DataController.shared.container.mainContext) {
+        self.context = context
+        setupBoard()
+    }
+
+    func setupBoard() {
+        tiles = (0..<8).map { row in
+            (0..<8).map { col in
+                LifeBoardTile(row: row, col: col, piece: nil)
+            }
+        }
+
+        if let storedPieces = try? context.fetch(FetchDescriptor<LifePieceState>()), !storedPieces.isEmpty {
+            pieces = storedPieces.map { state in
+                LifePiece(id: state.id, type: LifePieceType(rawValue: state.type) ?? .pawn, domain: state.domain, position: (state.row, state.col), progressLevel: state.progressLevel)
+            }
+        } else {
+            pieces = [
+                LifePiece(id: UUID(), type: .king, domain: "Virtue", position: (0,4), progressLevel: 5),
+                LifePiece(id: UUID(), type: .queen, domain: "Time", position: (0,3), progressLevel: 7)
+            ]
+            for piece in pieces {
+                let state = LifePieceState(id: piece.id, type: piece.type.rawValue, domain: piece.domain, row: piece.position.0, col: piece.position.1, progressLevel: piece.progressLevel)
+                context.insert(state)
+            }
+            try? context.save()
+        }
+
+        for piece in pieces {
+            tiles[piece.position.0][piece.position.1].piece = piece
+        }
+    }
+
+    func move(_ piece: LifePiece, to newPos: (Int, Int)) {
+        guard (0..<8).contains(newPos.0), (0..<8).contains(newPos.1) else { return }
+        guard let idx = pieces.firstIndex(where: { $0.id == piece.id }) else { return }
+
+        tiles[pieces[idx].position.0][pieces[idx].position.1].piece = nil
+        pieces[idx].position = newPos
+        tiles[newPos.0][newPos.1].piece = pieces[idx]
+
+        if let state = try? context.fetch(FetchDescriptor<LifePieceState>(predicate: #Predicate { $0.id == piece.id })).first {
+            state.row = newPos.0
+            state.col = newPos.1
+            try? context.save()
+        }
+    }
+}
+

--- a/LifeOSApp/ViewModels/WeeklyReportViewModel.swift
+++ b/LifeOSApp/ViewModels/WeeklyReportViewModel.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftData
+
+@MainActor
+class WeeklyReportViewModel: ObservableObject {
+    @Published var summary: String = ""
+    private let context: ModelContext
+
+    init(context: ModelContext = DataController.shared.container.mainContext) {
+        self.context = context
+    }
+
+    func generateReport() {
+        let fetchRequest = FetchDescriptor<LifePieceState>()
+        let pieces = (try? context.fetch(fetchRequest)) ?? []
+        let events = (try? context.fetch(FetchDescriptor<ChaosEvent>())) ?? []
+
+        var lines: [String] = []
+        lines.append("Pieces progress:")
+        for piece in pieces {
+            lines.append("- \(piece.domain): level \(piece.progressLevel)")
+        }
+        lines.append("Chaos events: \(events.count)")
+        summary = lines.joined(separator: "\n")
+    }
+}

--- a/LifeOSApp/Views/ArchetypeSelectorView.swift
+++ b/LifeOSApp/Views/ArchetypeSelectorView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct ArchetypeSelectorView: View {
+    @Binding var selected: Archetype
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 16) {
+                ForEach(Archetype.allCases) { archetype in
+                    VStack {
+                        Text(archetype.rawValue.capitalized)
+                            .font(.headline)
+                        Text(archetype.description)
+                            .font(.caption)
+                            .multilineTextAlignment(.center)
+                        Button("Select") {
+                            selected = archetype
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+                    .padding()
+                    .background(RoundedRectangle(cornerRadius: 8).stroke(Color.blue))
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    StateWrapper()
+}
+
+private struct StateWrapper: View {
+    @State var selected: Archetype = .franklin
+    var body: some View {
+        ArchetypeSelectorView(selected: $selected)
+    }
+}

--- a/LifeOSApp/Views/ChessboardView.swift
+++ b/LifeOSApp/Views/ChessboardView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct ChessboardView: View {
+    @Binding var archetype: Archetype
+    @StateObject private var viewModel = ChessboardViewModel()
+    @State private var selected: LifePiece?
+
+    var body: some View {
+        VStack {
+            Text("\(archetype.rawValue.capitalized) Mode")
+                .font(.headline)
+            Text("Life OS Chessboard")
+                .font(.largeTitle)
+                .padding(.bottom)
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 8), spacing: 2) {
+                ForEach(viewModel.tiles.flatMap { $0 }) { tile in
+                    ZStack {
+                        Rectangle()
+                            .fill((tile.row + tile.col) % 2 == 0 ? Color.gray.opacity(0.3) : Color.gray.opacity(0.6))
+                            .frame(height: 44)
+                            .onTapGesture {
+                                if let selected = selected {
+                                    viewModel.move(selected, to: (tile.row, tile.col))
+                                    self.selected = nil
+                                }
+                            }
+                        if let piece = tile.piece {
+                            Text(String(piece.type.rawValue.prefix(1)).uppercased())
+                                .foregroundColor(.white)
+                                .frame(width: 32, height: 32)
+                                .background(selected?.id == piece.id ? Color.green : Color.blue)
+                                .clipShape(Circle())
+                                .onTapGesture {
+                                    selected = piece
+                                }
+                                .overlay(
+                                    Text("\(piece.progressLevel)")
+                                        .font(.caption2)
+                                        .foregroundColor(.yellow)
+                                        .offset(x: 10, y: 10)
+                                )
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    StateWrapper()
+}
+
+private struct StateWrapper: View {
+    @State var archetype: Archetype = .franklin
+    var body: some View {
+        ChessboardView(archetype: $archetype)
+    }
+}

--- a/LifeOSApp/Views/PersonaQuizView.swift
+++ b/LifeOSApp/Views/PersonaQuizView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct QuizQuestion {
+    let text: String
+    let options: [Archetype]
+}
+
+struct PersonaQuizView: View {
+    @State private var index = 0
+    @State private var scores: [Archetype:Int] = [:]
+
+    private let questions: [QuizQuestion] = [
+        QuizQuestion(text: "How do you start your day?", options: [.franklin, .aurelius, .musashi]),
+        QuizQuestion(text: "Preferred focus?", options: [.daVinci, .tesla, .franklin])
+    ]
+
+    var body: some View {
+        VStack(spacing: 20) {
+            if index < questions.count {
+                Text(questions[index].text)
+                    .font(.headline)
+                ForEach(questions[index].options, id: \..self) { archetype in
+                    Button(archetype.rawValue.capitalized) {
+                        scores[archetype, default: 0] += 1
+                        index += 1
+                    }
+                    .buttonStyle(.bordered)
+                }
+            } else {
+                if let best = scores.max(by: { $0.value < $1.value })?.key {
+                    Text("You match \(best.rawValue.capitalized)")
+                        .font(.title2)
+                } else {
+                    Text("Quiz complete")
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    PersonaQuizView()
+}

--- a/LifeOSApp/Views/WeeklyReportView.swift
+++ b/LifeOSApp/Views/WeeklyReportView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct WeeklyReportView: View {
+    @StateObject private var viewModel = WeeklyReportViewModel()
+    @State private var shareSheet: Bool = false
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Text("Weekly Report")
+                .font(.title)
+            TextEditor(text: $viewModel.summary)
+                .frame(height: 200)
+                .border(Color.gray)
+            Button("Generate") {
+                viewModel.generateReport()
+            }
+            Button("Share") {
+                shareSheet = true
+            }
+            .disabled(viewModel.summary.isEmpty)
+            .sheet(isPresented: $shareSheet) {
+                ActivityView(activityItems: [viewModel.summary])
+            }
+        }
+        .padding()
+    }
+}
+
+struct ActivityView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
+    }
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}
+
+#Preview {
+    WeeklyReportView()
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
 # Casa-VidaOS
+
+Casa-VidaOS is an experimental Life Operating System for iOS built using Swift and SwiftUI. It visualizes your routines and goals as pieces on a chessboard. Inspired by historical figures like Benjamin Franklin and Leonardo da Vinci, the app encourages daily reflection, habit tracking, and virtue cultivation.
+
+## Features
+- Interactive chessboard dashboard representing life domains
+- Virtue tracker with weekly focus
+- Challenge engine to maintain habit streaks
+- Chaos Engine introducing random events
+- Archetype selector representing different play styles
+- Journal for morning and evening reflection
+- Persistent storage powered by SwiftData
+- Shareable weekly progress reports
+
+## Project Structure
+```
+Casa-VidaOS/
+├── README.md
+├── docs/
+│   ├── DESIGN.md
+│   ├── SCALING.md
+│   └── wireframes/
+└── LifeOSApp/
+    ├── Models/
+    ├── Views/
+    ├── ViewModels/
+    └── CasaVidaOSApp.swift
+├── backend/
+```
+
+## Getting Started
+1. Open `LifeOSApp` as an Xcode project or integrate these files into a new SwiftUI project.
+2. Build and run the app on iOS 17 or later.
+3. Use the "Weekly Report" link in the main interface to generate and share progress summaries.
+
+## Building
+This repository only includes Swift source files. Create an Xcode project named **LifeOSApp** and add the contents of `LifeOSApp/`. Ensure SwiftData/CoreData capability is enabled for persistence.
+
+For backend deployment and scaling guidance, see `docs/SCALING.md`.
+
+## License
+MIT

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,11 @@
+# LifeOS Backend Microservice
+
+This Node.js service provides user management endpoints for Casa-VidaOS.
+It demonstrates a scalable pattern using PostgreSQL for persistent storage
+and Redis as a caching layer. Deploy multiple instances behind a load
+balancer for horizontal scaling.
+
+## Setup
+1. Install dependencies with `npm install`.
+2. Set environment variables `DATABASE_URL` and `REDIS_URL`.
+3. Start the service using `node server.js`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "lifeos-backend",
+  "version": "0.1.0",
+  "main": "server.js",
+  "dependencies": {
+    "express": "^4.18.2",
+    "pg": "^8.11.0",
+    "redis": "^4.6.7"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const { Pool } = require('pg');
+const redis = require('redis');
+
+// PostgreSQL connection pool (replace with env vars in production)
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL || 'postgres://user:pass@localhost:5432/lifeos'
+});
+
+// Redis client for caching
+const redisClient = redis.createClient({
+  url: process.env.REDIS_URL || 'redis://localhost:6379'
+});
+redisClient.connect().catch(console.error);
+
+const app = express();
+app.use(express.json());
+
+// Simple user endpoint
+app.post('/api/signup', async (req, res) => {
+  const { email, password } = req.body;
+  try {
+    const result = await pool.query('INSERT INTO users(email, password) VALUES($1,$2) RETURNING id', [email, password]);
+    res.status(201).json({ id: result.rows[0].id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+app.get('/api/user/:id', async (req, res) => {
+  const { id } = req.params;
+  const cacheKey = `user:${id}`;
+  try {
+    const cached = await redisClient.get(cacheKey);
+    if (cached) {
+      return res.json(JSON.parse(cached));
+    }
+    const result = await pool.query('SELECT id, email FROM users WHERE id=$1', [id]);
+    if (result.rows.length === 0) return res.status(404).json({ error: 'Not found' });
+    const user = result.rows[0];
+    await redisClient.set(cacheKey, JSON.stringify(user), { EX: 60 }); // cache for 60s
+    res.json(user);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`Server running on ${port}`));

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,0 +1,53 @@
+# Casa-VidaOS Design
+
+Casa-VidaOS is built using the Model-View-ViewModel (MVVM) pattern. Each major feature is encapsulated in its own engine module to allow future expansion.
+
+## Modules
+- **ChessboardEngine** – Renders an 8x8 board and moves pieces based on habits and challenges.
+- **JournalEngine** – Handles morning/evening reflections stored via Core Data.
+- **ChallengeEngine** – Manages habit streaks and random chaos events.
+- **ArchetypeEngine** – Allows users to switch between historical archetypes such as Benjamin Franklin or Musashi. Each archetype can influence the UI theme and default challenges.
+
+## Data Models
+```swift
+enum LifePieceType: String, CaseIterable, Identifiable {
+    case king, queen, rook, bishop, knight, pawn
+    var id: String { rawValue }
+}
+
+struct LifePiece: Identifiable {
+    let id: UUID
+    let type: LifePieceType
+    let domain: String
+    var position: (Int, Int)
+    var progressLevel: Int
+}
+
+enum Archetype: String, CaseIterable {
+    case franklin, daVinci, tesla, aurelius, musashi
+}
+```
+
+## Views
+- **ChessboardView** – Displays the grid of tiles with piece icons.
+- **ArchetypeSelectorView** – Cards for each archetype with descriptions.
+- **JournalView** – Morning and evening prompts.
+- **PersonaQuizView** – Suggests an archetype after a short questionnaire.
+
+## Wireframes
+Wireframe images should be placed in `docs/wireframes/`. They illustrate the chessboard layout and the archetype selector carousel.
+
+## Features Implemented
+- Persistent storage using SwiftData.
+- Chaos Engine scheduling random events.
+- Weekly progress reports that can be shared.
+
+## Architecture
+The app follows MVVM. Each engine exposes a view model conforming to `ObservableObject` so SwiftUI views stay reactive. Core data types are stored using SwiftData or CoreData. The top-level `CasaVidaOSApp` composes `ArchetypeSelectorView` and `ChessboardView`.
+
+## User Stories
+- **Franklin User** – "Track my 13 virtues daily on the board." 
+- **Tesla User** – "Advance the Queen of Time by completing deep work blocks." 
+- **Da Vinci User** – "Leap my curiosity Knight whenever I log a new question." 
+- **Musashi User** – "Disable distractions and mark discipline for the Body rook." 
+

--- a/docs/SCALING.md
+++ b/docs/SCALING.md
@@ -1,0 +1,33 @@
+# Scaling Casa-VidaOS for Millions of Users
+
+This document outlines strategies to make the Life OS app robust enough to handle a very large user base.
+
+## 1. Backend Architecture
+- **Cloud-based hosting** on AWS, Google Cloud, or Azure with auto-scaling groups or serverless functions.
+- **Microservices** that separate authentication, journaling, habits, analytics, and other engines so they can scale independently.
+
+## 2. Data Storage
+- **Distributed databases** such as Amazon DynamoDB, Cloud Firestore, or sharded PostgreSQL clusters for high availability.
+- **Caching layer** with Redis or Memcached for frequently accessed data to reduce database load.
+
+## 3. API & Networking
+- **REST or GraphQL API** behind a load balancer for stateless requests from the mobile app.
+- **Rate limiting and retries** to handle spikes gracefully.
+
+## 4. User Management
+- Use proven authentication providers like Auth0, Firebase Auth, or Cognito.
+- Design for **data isolation** so each user's records can be sharded or migrated as the user base grows.
+
+## 5. App Design
+- **Efficient sync logic** to send only incremental changes between client and server.
+- **Background updates** with silent push notifications or scheduled tasks.
+
+## 6. Monitoring and Analytics
+- Instrument services with CloudWatch, Datadog, or Firebase Analytics.
+- Set up automatic scaling policies based on CPU, memory, and request rates.
+
+## 7. Security & Compliance
+- Encrypt data in transit (TLS) and at rest.
+- Implement privacy controls compliant with GDPR, CCPA, and other regulations.
+
+By following these guidelines, Casa-VidaOS can expand to millions of daily users without sacrificing performance or reliability.

--- a/docs/USER_STORIES.md
+++ b/docs/USER_STORIES.md
@@ -1,0 +1,6 @@
+# User Stories
+
+- As a **Franklin-mode** user, I track daily virtues on the board as checkmarks.
+- As a **Tesla-mode** user, completing deep work advances my Queen of Time.
+- As a **Da Vinci-mode** user, logging a curiosity leaps my Knight piece.
+- As a **Musashi-mode** user, disabling distractions logs discipline for my Body rook.

--- a/docs/wireframes/README.md
+++ b/docs/wireframes/README.md
@@ -1,0 +1,3 @@
+These text wireframes illustrate the key views:
+- `chessboard_wireframe.txt` shows the 8x8 grid layout with pieces.
+- `archetype_selector_wireframe.txt` outlines the horizontal archetype cards.

--- a/docs/wireframes/archetype_selector_wireframe.txt
+++ b/docs/wireframes/archetype_selector_wireframe.txt
@@ -1,0 +1,3 @@
+Archetype Selector Wireframe
+[Franklin] [daVinci] [Tesla] [Aurelius] [Musashi]
+Horizontal scroll with portrait and "Select" button on each card.

--- a/docs/wireframes/chessboard_wireframe.txt
+++ b/docs/wireframes/chessboard_wireframe.txt
@@ -1,0 +1,13 @@
+8x8 grid representing life domains
+
+   A B C D E F G H
+ 1 [ ] [ ] [ ] [ ] [ ] [ ] [ ] [ ]
+ 2 [ ] [ ] [ ] [ ] [ ] [ ] [ ] [ ]
+ 3 [ ] [ ] [ ] [ ] [ ] [ ] [ ] [ ]
+ 4 [ ] [ ] [ ] [ ] [ ] [ ] [ ] [ ]
+ 5 [ ] [ ] [ ] [ ] [ ] [ ] [ ] [ ]
+ 6 [ ] [ ] [ ] [ ] [ ] [ ] [ ] [ ]
+ 7 [ ] [ ] [ ] [ ] [ ] [ ] [ ] [ ]
+ 8 [ ] [ ] [ ] [ ] [ ] [ ] [ ] [ ]
+
+Pieces sit on tiles and move when habits are completed.


### PR DESCRIPTION
## Summary
- add SwiftData models and DataController for persistence
- implement ChaosEngine with scheduled events
- generate shareable weekly reports
- persist chess piece state when moving
- document new features in README and DESIGN docs

## Testing
- `swift --version`
- `swiftc LifeOSApp/Models/LifeModels.swift -o /tmp/out`
- `swiftc LifeOSApp/Persistence/DataController.swift -o /tmp/dc` *(fails: no such module 'SwiftData')*

------
https://chatgpt.com/codex/tasks/task_e_6840a6576e808332b891ce7acde34f70